### PR TITLE
65 long matches truncated with ellipsis

### DIFF
--- a/src/views/textview/text-view-middle.js
+++ b/src/views/textview/text-view-middle.js
@@ -129,6 +129,9 @@ export class TextView extends LitElement {
         if (positionFlag === 1) {
           let parSegnr = segmentArrayToString(selectedParallels[i].par_segnr);
           let segnrText = selectedParallels[i].par_segtext;
+          if (segnrText.length > 2) {
+            segnrText.splice(1, segnrText.length - 2, '…');
+          }
           const par_lang = getLanguageFromFilename(
             selectedParallels[i].par_segnr[0]
           );

--- a/src/views/textview/text-view-middle.js
+++ b/src/views/textview/text-view-middle.js
@@ -1,5 +1,5 @@
 import { customElement, html, LitElement, property } from 'lit-element';
-
+import { truncateSegnrText } from './textViewUtils';
 import { sortByKey, getLanguageFromFilename } from '../utility/views-common';
 import {
   highlightTextByOffset,
@@ -129,9 +129,8 @@ export class TextView extends LitElement {
         if (positionFlag === 1) {
           let parSegnr = segmentArrayToString(selectedParallels[i].par_segnr);
           let segnrText = selectedParallels[i].par_segtext;
-          if (segnrText.length > 2) {
-            segnrText.splice(1, segnrText.length - 2, '…');
-          }
+          segnrText = truncateSegnrText(segnrText);
+
           const par_lang = getLanguageFromFilename(
             selectedParallels[i].par_segnr[0]
           );

--- a/src/views/textview/textViewUtils.js
+++ b/src/views/textview/textViewUtils.js
@@ -101,3 +101,14 @@ export const highlightActiveMainElement = (
   }
   return colourValues;
 };
+
+export const truncateSegnrText = segnrText => {
+  var lengths = segnrText.map(function(segment) {
+    return segment.length;
+  });
+  const sumLength = lengths.reduce((partial_sum, a) => partial_sum + a, 0);
+  if (sumLength > 500) {
+    segnrText.splice(1, segnrText.length - 2, '…');
+    return segnrText;
+  } else return segnrText;
+};

--- a/src/views/textview/textViewUtils.js
+++ b/src/views/textview/textViewUtils.js
@@ -108,7 +108,11 @@ export const truncateSegnrText = segnrText => {
   });
   const sumLength = lengths.reduce((partial_sum, a) => partial_sum + a, 0);
   if (sumLength > 500) {
-    segnrText.splice(1, segnrText.length - 2, '…');
+    segnrText.splice(
+      1,
+      segnrText.length - 2,
+      '… this text has been truncated …'
+    );
     return segnrText;
   } else return segnrText;
 };

--- a/src/views/utility/preprocessing.js
+++ b/src/views/utility/preprocessing.js
@@ -50,26 +50,35 @@ export const highlightTextByOffset = (
     let colourValues = [];
     let position = 0;
     let Words = textArray[i];
-    if (lang.match(/tib|pli/)) {
-      Words = textArray[i].split(' ');
-    }
-    for (let j = 0; j < Words.length; ++j) {
-      WordList.push(position);
-      let colourValue = 1;
-      position += Words[j].length;
+
+    if (Words === '… this text has been truncated …') {
+      returnArray.push(
+        html`
+          <span style="color: #E80C0C; font-style: oblique;">${Words}</span>
+        `
+      );
+    } else {
       if (lang.match(/tib|pli/)) {
-        position += 1;
+        Words = textArray[i].split(' ');
       }
-      if (i === 0 && position <= startoffset) {
-        colourValue = 0;
+      for (let j = 0; j < Words.length; ++j) {
+        WordList.push(position);
+        let colourValue = 1;
+        position += Words[j].length;
+        if (lang.match(/tib|pli/)) {
+          position += 1;
+        }
+        if (i === 0 && position <= startoffset) {
+          colourValue = 0;
+        }
+        if (i === textArray.length - 1 && position > endoffset) {
+          colourValue = 0;
+        }
+        colourValues.push(colourValue);
       }
-      if (i === textArray.length - 1 && position > endoffset) {
-        colourValue = 0;
-      }
-      colourValues.push(colourValue);
+      let tokenizedResult = tokenizeWords(textArray[i], lang, colourValues);
+      returnArray.push(tokenizedResult);
     }
-    let tokenizedResult = tokenizeWords(textArray[i], lang, colourValues);
-    returnArray.push(tokenizedResult);
   }
   return returnArray;
 };


### PR DESCRIPTION
Have a look at this solution: basically it takes the text for the parallel and if it is more than 2 segments, it replaces the middle segments with an ellipsis. This does not mess with the highlighting code.
You can also make it a bit longer if you want by saying longer than 4 segments and leaving the first and last two.