### PR TITLE
delay start load totals on filechange only

### DIFF
--- a/src/views/utility/total-numbers.js
+++ b/src/views/utility/total-numbers.js
@@ -16,16 +16,14 @@ export class TotalNumbers extends LitElement {
 
   updated(_changedProperties) {
     _changedProperties.forEach((oldValue, propName) => {
-      if (
-        [
-          'fileName',
-          'score',
-          'cooccurance',
-          'quoteLength',
-          'limitCollection',
-        ].includes(propName)
-      ) {
+      if (['fileName'].includes(propName)) {
         setTimeout(this.startLoading.bind(this), 2000);
+      } else if (
+        ['score', 'cooccurance', 'quoteLength', 'limitCollection'].includes(
+          propName
+        )
+      ) {
+        this.startLoading();
       }
     });
   }

--- a/src/views/utility/total-numbers.js
+++ b/src/views/utility/total-numbers.js
@@ -16,7 +16,7 @@ export class TotalNumbers extends LitElement {
 
   updated(_changedProperties) {
     _changedProperties.forEach((oldValue, propName) => {
-      if (['fileName'].includes(propName)) {
+      if (propName === 'fileName') {
         setTimeout(this.startLoading.bind(this), 2000);
       } else if (
         ['score', 'cooccurance', 'quoteLength', 'limitCollection'].includes(


### PR DESCRIPTION
This is not a totally satisfactory solution because you cannot do it the same way with a change from/to graph mode but now it only delays the loading of the totals by 2 seconds when a new filename is chosen. 