### PR TITLE
Fix reload after text search

### DIFF
--- a/src/views/data/data-view-header-fields.js
+++ b/src/views/data/data-view-header-fields.js
@@ -269,7 +269,7 @@ export class DataViewHeaderFields extends LitElement {
                   <vaadin-item value="position"
                     >By position in Inquiry Text</vaadin-item
                   >
-                  <vaadin-item value="quoted-text" disabled
+                  <vaadin-item value="quoted-text"
                     >By position in Hit Text(s)</vaadin-item
                   >
                   <vaadin-item value="length" disabled

--- a/src/views/data/data-view.js
+++ b/src/views/data/data-view.js
@@ -126,6 +126,7 @@ export class DataView extends LitElement {
 
   setSelectedView = viewName => {
     this.selectedView = viewName;
+    this.viewMode = viewName;
   };
 
   setFolio = folio => {


### PR DESCRIPTION
Tiny fix for the reloading after local search was used & bring back sort-by-hit-text.