### PR TITLE
fixes bug in loading patimokkha from menu

### DIFF
--- a/src/views/menus/navigation-menu.js
+++ b/src/views/menus/navigation-menu.js
@@ -68,7 +68,8 @@ export class NavigationMenu extends LitElement {
             id="${file.filename}"
             @click="${this.openThisFile}"
           >
-            <strong>${file.textname}</strong> ${file.displayname}
+            <strong id="${file.filename}">${file.textname}</strong>
+            ${file.displayname}
           </li>
         `
       );

--- a/src/views/utility/formatted-segment.js
+++ b/src/views/utility/formatted-segment.js
@@ -95,11 +95,11 @@ export class FormattedFileName extends LitElement {
   }
 
   render() {
-    if (this.fetchLoading) {
+    if (this.fetchLoading || !this.displayName) {
       // prettier-ignore
-      return html`<span class="formatted-file-name" name="${this.displayName}">${this.filename} ###</span>`
+      return html`<span class="formatted-file-name" name="${this.displayName}">${this.filename}</span>`
     }
     // prettier-ignore
-    return html`<span class="formatted-file-name ${this.rightside}" name="${this.displayName}">${this.textName} </span>`
+    return html`<span class="formatted-file-name ${this.rightside}" name="${this.displayName}">${this.textName}</span>`
   }
 }


### PR DESCRIPTION
This is a complete hack but apparently if in the menu you click on the `<strong>` filename it cannot find the file because the id is on the list element and not the strong element so both need to have the same id to make it work.

The other file is just a bit of cleanup - I take it the ### was a mistake.