### PR TITLE
247 set minimum values

### DIFF
--- a/src/views/data/data-view-filter-sliders.js
+++ b/src/views/data/data-view-filter-sliders.js
@@ -5,6 +5,7 @@ export default class DataViewFilterSliders extends LitElement {
   @property({ type: Number }) score;
   @property({ type: Function }) updateScore;
   @property({ type: Number }) quoteLength;
+  @property({ type: Number }) minLength;
   @property({ type: Function }) updateQuoteLength;
 
   static get styles() {
@@ -87,7 +88,7 @@ export default class DataViewFilterSliders extends LitElement {
             value="${this.quoteLength}"
             @change="${this.updateQuoteLength}"
             max="300"
-            min="5"
+            min="${this.minLength.toString()}"
             editable>
           </paper-slider>
         </div>

--- a/src/views/data/data-view-filters-container.js
+++ b/src/views/data/data-view-filters-container.js
@@ -35,6 +35,7 @@ export class DataViewFiltersContainer extends LitElement {
   @property({ type: Number }) score;
   @property({ type: Function }) updateScore;
   @property({ type: Number }) quoteLength;
+  @property({ type: Number }) minLength;
   @property({ type: Function }) updateQuoteLength;
   @property({ type: Number }) cooccurance;
   @property({ type: Function }) updateCooccurance;
@@ -236,6 +237,7 @@ export class DataViewFiltersContainer extends LitElement {
       <data-view-filter-sliders .score="${this.score}" 
       .updateScore="${this.updateScore}" 
       .quoteLength="${this.quoteLength}" 
+      .minLength="${this.minLength}"
       .updateQuoteLength="${this.updateQuoteLength}" 
       .cooccurance="${this.cooccurance}" 
       .updateCooccurance="${this.updateCooccurance}">

--- a/src/views/data/data-view-subheader.js
+++ b/src/views/data/data-view-subheader.js
@@ -7,7 +7,49 @@ import '@vaadin/vaadin-icons/vaadin-icons.js';
 
 import '../utility/formatted-segment';
 
-import { LANGUAGE_CODES } from '../utility/constants';
+import {
+  LANGUAGE_CODES,
+  LANGUAGE_NAMES,
+  MIN_LENGTHS,
+} from '../utility/constants';
+
+export const minimumLengthText = language => {
+  let minLength;
+  let languageFull;
+  let charOrSyl;
+  switch (language) {
+    case LANGUAGE_CODES.TIBETAN:
+      minLength = MIN_LENGTHS.TIBETAN;
+      languageFull = LANGUAGE_NAMES.TIBETAN;
+      charOrSyl = 'syllables';
+      break;
+    case LANGUAGE_CODES.PALI:
+      minLength = MIN_LENGTHS.PALI;
+      languageFull = LANGUAGE_NAMES.PALI;
+      charOrSyl = 'letters';
+      break;
+    case LANGUAGE_CODES.SANSKRIT:
+      minLength = MIN_LENGTHS.SANSKRIT;
+      languageFull = LANGUAGE_NAMES.SANSKRIT;
+      charOrSyl = 'letters';
+      break;
+    case LANGUAGE_CODES.CHINESE:
+      minLength = MIN_LENGTHS.CHINESE;
+      languageFull = LANGUAGE_NAMES.CHINESE;
+      charOrSyl = 'characters';
+      break;
+    default:
+      minLength = MIN_LENGTHS.TIBETAN;
+      languageFull = LANGUAGE_NAMES.TIBETAN;
+      charOrSyl = 'syllables';
+  }
+  return html`
+    <p>
+      <strong>NOTE</strong>: The minimum Match Length for ${languageFull} texts
+      has been set to ${minLength} ${charOrSyl}.
+    </p>
+  `;
+};
 
 @customElement('data-view-subheader')
 class DataViewSubheader extends LitElement {
@@ -83,14 +125,7 @@ class DataViewSubheader extends LitElement {
           @opened-changed="${this.setIsDialogOpen}">
           <template>
             ${this.infoModalContent}
-            ${this.language === LANGUAGE_CODES.PALI
-              ? html`
-                  <p>
-                    <strong>NOTE</strong>: For technical reasons, the
-                    co-occurances for Pāḷi texts are limited to maximum 50.
-                  </p>
-                `
-              : ''}
+            ${minimumLengthText(this.language)}
           </template>
         </vaadin-dialog>
 

--- a/src/views/data/data-view.js
+++ b/src/views/data/data-view.js
@@ -23,13 +23,19 @@ import { getLanguageFromFilename } from '../utility/views-common';
 import dataViewStyles from './data-view.styles';
 import { getMainLayout } from '../utility/utils';
 import { DATA_VIEW_MODES } from './data-view-filters-container';
+import {
+  LANGUAGE_CODES,
+  MIN_LENGTHS,
+  DEFAULT_SCORES,
+} from '../utility/constants';
 
 @customElement('data-view')
 export class DataView extends LitElement {
   @property({ type: String }) fileName = '';
   @property({ type: String }) language;
-  @property({ type: Number }) score = 60;
-  @property({ type: Number }) quoteLength = 12;
+  @property({ type: Number }) score;
+  @property({ type: Number }) quoteLength;
+  @property({ type: Number }) minLength;
   @property({ type: Number }) cooccurance = 2000; // just put it to a high value so it is practically disabled per default.
   @property({ type: Array }) targetCollection = [];
   @property({ type: Array }) limitCollection = [];
@@ -58,9 +64,28 @@ export class DataView extends LitElement {
   firstUpdated(_changedProperties) {
     super.firstUpdated(_changedProperties);
     this.handleViewModeParamChanged();
-    this.cooccurance = this.language === 'pli' ? 15 : 2000;
-    this.quoteLength = this.language === 'chn' ? 7 : 12;
-    this.score = this.language === 'chn' ? 30 : 60;
+    switch (this.language) {
+      case LANGUAGE_CODES.TIBETAN:
+        this.quoteLength = MIN_LENGTHS.TIBETAN;
+        this.score = DEFAULT_SCORES.TIBETAN;
+        break;
+      case LANGUAGE_CODES.PALI:
+        this.quoteLength = MIN_LENGTHS.PALI;
+        this.score = DEFAULT_SCORES.PALI;
+        break;
+      case LANGUAGE_CODES.SANSKRIT:
+        this.quoteLength = MIN_LENGTHS.SANSKRIT;
+        this.score = DEFAULT_SCORES.SANSKRIT;
+        break;
+      case LANGUAGE_CODES.CHINESE:
+        this.quoteLength = MIN_LENGTHS.CHINESE;
+        this.score = DEFAULT_SCORES.CHINESE;
+        break;
+      default:
+        this.quoteLength = MIN_LENGTHS.TIBETAN;
+        this.score = DEFAULT_SCORES.TIBETAN;
+    }
+    this.minLength = this.quoteLength;
     this.checkSelectedView();
   }
 
@@ -310,6 +335,7 @@ export class DataView extends LitElement {
             .score="${this.score}"
             .updateScore="${this.setScore}"
             .quoteLength="${this.quoteLength}"
+            .minLength="${this.minLength}"
             .updateQuoteLength="${this.setQuoteLength}"
             .updateLimitCollection="${this.setLimitCollection}"
             .updateTargetCollection="${this.setTargetCollection}"

--- a/src/views/neutralview/neutral-view-chinese.js
+++ b/src/views/neutralview/neutral-view-chinese.js
@@ -5,10 +5,12 @@ import styles from './neutral-view.styles';
 
 @customElement('neutral-view-chinese')
 export class NeutralViewChinese extends LitElement {
-  @property({ type: String }) lang;
+  @property({ type: String }) minLengthText;
+
   static get styles() {
     return [styles, sharedDataViewStyles];
   }
+
   render() {
     return html`
       <div class="static-page-container lang_chn">
@@ -27,6 +29,7 @@ export class NeutralViewChinese extends LitElement {
               five or more syllables, such instances have been filtered from the
               results.
             </p>
+            ${this.minLengthText}
             <span class="copyright"
               >Background image with courtesy to the ICABS, Tokyo(via Prof.
               Ochiai).</span

--- a/src/views/neutralview/neutral-view-pali.js
+++ b/src/views/neutralview/neutral-view-pali.js
@@ -5,10 +5,12 @@ import styles from './neutral-view.styles';
 
 @customElement('neutral-view-pali')
 export class NeutralViewPali extends LitElement {
-  @property({ type: String }) lang;
+  @property({ type: String }) minLengthText;
+
   static get styles() {
     return [styles, sharedDataViewStyles];
   }
+
   render() {
     return html`
       <div class="static-page-container lang_pli">
@@ -40,6 +42,7 @@ export class NeutralViewPali extends LitElement {
               For the calculation of the Pāli matches, SuttaCentral's
               hyphenation and stemming algorithms have been used.
             </p>
+            ${this.minLengthText}
             <span class="copyright"
               >Background image with courtesy to the Fragile Palm Leaves
               Collection, Bangkok.</span

--- a/src/views/neutralview/neutral-view-sanskrit.js
+++ b/src/views/neutralview/neutral-view-sanskrit.js
@@ -5,10 +5,12 @@ import styles from './neutral-view.styles';
 
 @customElement('neutral-view-sanskrit')
 export class NeutralViewSanskrit extends LitElement {
-  @property({ type: String }) lang;
+  @property({ type: String }) minLengthText;
+
   static get styles() {
     return [styles, sharedDataViewStyles];
   }
+
   render() {
     return html`
       <div class="static-page-container lang_skt">
@@ -38,6 +40,7 @@ export class NeutralViewSanskrit extends LitElement {
               has been used. This stemming algorithm is accessible as a
               standalone application <a href="/tools/sanskrit">here</a>.
             </p>
+            ${this.minLengthText}
             <span class="copyright"
               >Background image with courtesy to the Nepal-German Manuscript
               Preservation Project (NGMPP).</span

--- a/src/views/neutralview/neutral-view-tibetan.js
+++ b/src/views/neutralview/neutral-view-tibetan.js
@@ -5,10 +5,12 @@ import styles from './neutral-view.styles';
 
 @customElement('neutral-view-tibetan')
 export class NeutralViewTibetan extends LitElement {
-  @property({ type: String }) lang;
+  @property({ type: String }) minLengthText;
+
   static get styles() {
     return [styles, sharedDataViewStyles];
   }
+
   render() {
     return html`
       <div class="static-page-container lang_tib">
@@ -46,6 +48,7 @@ export class NeutralViewTibetan extends LitElement {
               between a pair of either a single or double stroke (shad) at the
               beginning and a double stroke at the end.
             </p>
+            ${this.minLengthText}
             <span class="copyright"
               >Background image with courtesy to Burkhard Quessel.</span
             >

--- a/src/views/neutralview/neutral-view.js
+++ b/src/views/neutralview/neutral-view.js
@@ -5,37 +5,40 @@ import './neutral-view-tibetan';
 import './neutral-view-chinese';
 import './neutral-view-pali';
 
-import sharedDataViewStyles from '../data/data-view-shared.styles';
-import styles from './neutral-view.styles';
 import { LANGUAGE_CODES } from '../utility/constants';
+import { minimumLengthText } from '../data/data-view-subheader';
 
 @customElement('neutral-view')
 export class NeutralView extends LitElement {
   @property({ type: String }) lang;
 
-  static get styles() {
-    return [styles, sharedDataViewStyles];
-  }
-
   render() {
     if (this.lang == LANGUAGE_CODES.SANSKRIT) {
       return html`
-        <neutral-view-sanskrit></neutral-view-sanskrit>
+        <neutral-view-sanskrit
+          .minLengthText="${minimumLengthText(this.lang)}"
+        ></neutral-view-sanskrit>
       `;
     }
     if (this.lang == LANGUAGE_CODES.TIBETAN) {
       return html`
-        <neutral-view-tibetan></neutral-view-tibetan>
+        <neutral-view-tibetan
+          .minLengthText="${minimumLengthText(this.lang)}"
+        ></neutral-view-tibetan>
       `;
     }
     if (this.lang == LANGUAGE_CODES.CHINESE) {
       return html`
-        <neutral-view-chinese></neutral-view-chinese>
+        <neutral-view-chinese
+          .minLengthText="${minimumLengthText(this.lang)}"
+        ></neutral-view-chinese>
       `;
     }
     if (this.lang == LANGUAGE_CODES.PALI) {
       return html`
-        <neutral-view-pali></neutral-view-pali>
+        <neutral-view-pali
+          .minLengthText="${minimumLengthText(this.lang)}"
+        ></neutral-view-pali>
       `;
     }
   }

--- a/src/views/textview/text-view-header.js
+++ b/src/views/textview/text-view-header.js
@@ -63,6 +63,7 @@ function TextViewHeaderLeftColumn({
   isInfoDialogLeftOpen,
   setIsInfoDialogLeftOpen,
   openDialogLeft,
+  language,
 }) {
   //prettier-ignore
   return html`
@@ -72,7 +73,7 @@ function TextViewHeaderLeftColumn({
       .opened="${isInfoDialogLeftOpen}"
       @opened-changed="${setIsInfoDialogLeftOpen}">
       <template>
-        ${TextViewInfoModalContent()}
+        ${TextViewInfoModalContent(language)}
       </template>
     </vaadin-dialog>
 
@@ -107,6 +108,7 @@ function TextViewHeaderLeftColumn({
 @customElement('text-view-header')
 export class TextViewHeader extends LitElement {
   @property({ type: String }) fileName;
+  @property({ type: String }) lang;
   @property({ type: Array }) limitCollection;
   @property({ type: Number }) quoteLength;
   @property({ type: Number }) cooccurance;
@@ -228,6 +230,7 @@ export class TextViewHeader extends LitElement {
             isInfoDialogLeftOpen: this.isInfoDialogLeftOpen,
             setIsInfoDialogLeftOpen: this.setIsInfoDialogLeftOpen,
             openDialogLeft: this.openDialogLeft,
+            language: this.lang,
           })}
         </div>
 

--- a/src/views/textview/text-view-modal-content.js
+++ b/src/views/textview/text-view-modal-content.js
@@ -1,8 +1,9 @@
 import { html } from 'lit-element';
 
 import { SEGMENT_COLORS } from '../utility/preprocessing';
+import { minimumLengthText } from '../data/data-view-subheader';
 
-export default function TextViewInfoModalContent() {
+export default function TextViewInfoModalContent(language) {
   return html`
     <div>
       <p>
@@ -33,6 +34,8 @@ export default function TextViewInfoModalContent() {
           <th></th>
         </tr>
       </table>
+
+      ${minimumLengthText(language)}
     </div>
   `;
 }

--- a/src/views/textview/text-view.js
+++ b/src/views/textview/text-view.js
@@ -204,6 +204,7 @@ export class TextView extends LitElement {
     return html`
       <text-view-header
         .fileName="${this.fileName}"
+        .lang="${this.lang}"
         .rightFileName="${this.rightFileName}"
         .rightSegmentName="${this.rightActiveSegment}"
         .score="${this.score}"

--- a/src/views/utility/constants.js
+++ b/src/views/utility/constants.js
@@ -4,3 +4,24 @@ export const LANGUAGE_CODES = {
   CHINESE: 'chn',
   SANSKRIT: 'skt',
 };
+
+export const MIN_LENGTHS = {
+  PALI: 30,
+  TIBETAN: 7,
+  CHINESE: 5,
+  SANSKRIT: 25,
+};
+
+export const LANGUAGE_NAMES = {
+  PALI: 'Pāḷi',
+  TIBETAN: 'Tibetan',
+  CHINESE: 'Chinese',
+  SANSKRIT: 'Sanskrit',
+};
+
+export const DEFAULT_SCORES = {
+  PALI: 30,
+  TIBETAN: 60,
+  CHINESE: 30,
+  SANSKRIT: 30,
+};

--- a/src/views/utility/formatted-segment.js
+++ b/src/views/utility/formatted-segment.js
@@ -57,7 +57,7 @@ export class FormattedSegment extends LitElement {
     const { displayData, error } = await getDisplayName({
       segmentnr: this.filename,
     });
-    this.displayName = displayData[0];
+    this.displayName = displayData ? displayData[0] : '';
     this.fetchLoading = false;
     this.allowFetching = false;
     this.fetchError = error;


### PR DESCRIPTION
Now all the minimum length values for all languages are in utility/constants so you only have to change these things in just 1 place.
This changes it in:
1. Text on neutral page (you might have to check this with Orna).
2. Text in the info buttons
3. Sets the minimum value of the slider (no point having it go lower and reloading on the server if lower does not exist).

Then also in those constants are the default values for the score for all languages.