### PR TITLE
Bug scrolling

### DIFF
--- a/src/views/numbersview/numbers-view-table.js
+++ b/src/views/numbersview/numbers-view-table.js
@@ -22,12 +22,18 @@ const NumbersViewTable = ({ fileName, collections, segments, language }) => {
   `;
 };
 
+function Comparator(a, b) {
+  if (a[0] < b[0]) return -1;
+  if (a[0] > b[0]) return 1;
+  return 0;
+}
+
 const NumbersViewTableContent = (segments, collectionkeys, language) =>
   segments.map(segment => {
     const collections = objectMap(collectionkeys, () => []);
     const { parallels: segmentParallels, segmentnr } = segment;
     return TableRowContainer(
-      segmentParallels ? segmentParallels : [],
+      segmentParallels ? segmentParallels.sort(Comparator) : [],
       collections,
       segmentnr,
       language

--- a/src/views/textview/text-view-left.js
+++ b/src/views/textview/text-view-left.js
@@ -92,6 +92,9 @@ export class TextViewLeft extends LitElement {
     this.parallels = {};
     this.textLeft = [];
     this.leftActiveSegment = this.leftTextData.selectedParallels[0];
+    this.currentPage = 0;
+    this.veryShortText = false;
+    this.reachedEndText = false;
     this.fetchNewText();
   }
 
@@ -101,6 +104,9 @@ export class TextViewLeft extends LitElement {
     this.textLeft = [];
     this.parallels = {};
     this.leftActiveSegment = undefined;
+    this.currentPage = 0;
+    this.veryShortText = false;
+    this.reachedEndText = false;
     this.fetchNewText();
   }
 
@@ -162,7 +168,6 @@ export class TextViewLeft extends LitElement {
 
   incrementPage() {
     this.currentPage = this.currentPage + 1;
-    //this.addedSegmentObservers = false;
   }
 
   async addSegmentObservers() {


### PR DESCRIPTION
This fixes 2 bugs:
1. The endless scrolling stopping because it has reached the end of one file but then takes that value with it to the next file and does not scroll any more at all. So this resets everything when the filename is changed.
2. sorting the numbers in the numbers view so they are actually in a good order and not random.