### PR TITLE
bug fix switching views loading

### DIFF
--- a/src/views/data/data-view.js
+++ b/src/views/data/data-view.js
@@ -203,7 +203,9 @@ export class DataView extends LitElement {
 
   setSortMethod = e => {
     this.sortMethod = e.target.value;
-    this.folio = '';
+    if (this.sortMethod != 'position') {
+      this.folio = '';
+    }
   };
 
   setLimitCollection = limitCollection => {


### PR DESCRIPTION
This is a bug fix for the bug discussed on gitter:
I go to table view dhammapada (dhp) and click on Verse 14. I get one result. This is correct. Then I click on numbers and back again to table view. Then table view has changed to not just show that one result that it should, but also lots of other results.
