### PR TITLE
Multilang menu icon

### DIFF
--- a/src/menu-data.js
+++ b/src/menu-data.js
@@ -76,6 +76,11 @@ export const navMenuDataMain = [
         text: 'Chinese',
         url: 'chn/neutral',
       },
+      {
+        text: 'Multilingual',
+        url: 'multi/neutral',
+      },
+	
     ],
   },
   {

--- a/src/menu-data.js
+++ b/src/menu-data.js
@@ -80,7 +80,6 @@ export const navMenuDataMain = [
         text: 'Multilingual',
         url: 'multi/neutral',
       },
-	
     ],
   },
   {

--- a/src/router.js
+++ b/src/router.js
@@ -205,6 +205,16 @@ const ROUTES = [
     },
   },
   {
+    path: '/multi/:viewMode?/:fileName?/:activeSegment?',
+    component: 'data-view',
+    action: () => {
+      import('./views/data/data-view.js');
+      switchNavbarLayout(false, false);
+      setLogoSource('/src/assets/img/buddhanexus.jpg');
+    },
+  },
+
+   {
     path: '/visual/:lang?',
     component: 'visual-view',
     action: () => {

--- a/src/views/data/data-view-header-fields.js
+++ b/src/views/data/data-view-header-fields.js
@@ -120,33 +120,36 @@ export class DataViewHeaderFields extends LitElement {
     }
   }
 
-    preprocessMenuData(menuData) {
-	// this function has a bit of spaghetti-style; maybe we can refactor it at some point.
-	return menuData.map(menuEntry => {
-	    menuEntry.imgStringPLI = '';
-	    menuEntry.imgStringSKT = '';
-	    menuEntry.imgStringTIB = '';
-	    menuEntry.imgStringCHN = '';
-	    if(menuEntry.available_lang.length > 0 ) {
-		menuEntry.available_lang.forEach(langItem => {
-		    if(langItem == "pli") {
-			menuEntry.imgStringPLI = '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
-		    }
-		    if(langItem == "skt") {
-			menuEntry.imgStringSKT = '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
-		    }
-		    if(langItem == "tib") {
-			menuEntry.imgStringTIB = '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
-		    }
-		    if(langItem == "chn") {
-			menuEntry.imgStringCHN = '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
-		    }
-		});
-	    }
-	    return menuEntry;
-	});
-	return menuData;
-    }
+  preprocessMenuData(menuData) {
+    // this function has a bit of spaghetti-style; maybe we can refactor it at some point.
+    return menuData.map(menuEntry => {
+      menuEntry.imgStringPLI = '';
+      menuEntry.imgStringSKT = '';
+      menuEntry.imgStringTIB = '';
+      menuEntry.imgStringCHN = '';
+      if (menuEntry.available_lang) {
+        menuEntry.available_lang.forEach(langItem => {
+          if (langItem == 'pli') {
+            menuEntry.imgStringPLI =
+              '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
+          }
+          if (langItem == 'skt') {
+            menuEntry.imgStringSKT =
+              '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
+          }
+          if (langItem == 'tib') {
+            menuEntry.imgStringTIB =
+              '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
+          }
+          if (langItem == 'chn') {
+            menuEntry.imgStringCHN =
+              '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
+          }
+        });
+      }
+      return menuEntry;
+    });
+  }
 
   getTextAndDisplayNames(results) {
     const textNameDic = {};
@@ -169,7 +172,7 @@ export class DataViewHeaderFields extends LitElement {
       language: this.language,
     });
 
-      this.menuData = this.preprocessMenuData(result);
+    this.menuData = this.preprocessMenuData(result);
 
     this.fetchError = error;
   }
@@ -186,7 +189,6 @@ export class DataViewHeaderFields extends LitElement {
         return 'Find Sanskrit texts...';
       case LANGUAGE_CODES.MULTILANG:
         return 'Find Multilingual texts...';
-
     }
   };
 

--- a/src/views/data/data-view-header-fields.js
+++ b/src/views/data/data-view-header-fields.js
@@ -120,6 +120,34 @@ export class DataViewHeaderFields extends LitElement {
     }
   }
 
+    preprocessMenuData(menuData) {
+	// this function has a bit of spaghetti-style; maybe we can refactor it at some point. 
+	return menuData.map(menuEntry => {
+	    menuEntry.imgStringPLI = '';
+	    menuEntry.imgStringSKT = '';
+	    menuEntry.imgStringTIB = '';
+	    menuEntry.imgStringCHN = '';	    
+	    if(menuEntry.available_lang.length > 0 ) {
+		menuEntry.available_lang.forEach(langItem => {
+		    if(langItem == "pli") {
+			menuEntry.imgStringPLI = '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
+		    }
+		    if(langItem == "skt") {
+			menuEntry.imgStringSKT = '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
+		    }
+		    if(langItem == "tib") {
+			menuEntry.imgStringTIB = '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
+		    }
+		    if(langItem == "chn") {
+			menuEntry.imgStringCHN = '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
+		    }
+		});
+	    }
+	    return menuEntry;
+	});
+	return menuData;
+    }
+
   getTextAndDisplayNames(results) {
     const textNameDic = {};
     const displayNameDic = {};
@@ -141,7 +169,8 @@ export class DataViewHeaderFields extends LitElement {
       language: this.language,
     });
 
-    this.menuData = result;
+      this.menuData = this.preprocessMenuData(result);
+
     this.fetchError = error;
   }
 
@@ -155,6 +184,9 @@ export class DataViewHeaderFields extends LitElement {
         return 'Find Chinese texts...';
       case LANGUAGE_CODES.SANSKRIT:
         return 'Find Sanskrit texts...';
+      case LANGUAGE_CODES.MULTILANG:
+        return 'Find Multilingual texts...';
+
     }
   };
 
@@ -229,11 +261,22 @@ export class DataViewHeaderFields extends LitElement {
               max-width: 200px;
               -webkit-line-clamp: 2;
               -webkit-box-orient: vertical;
-              overflow: hidden;
-              text-overflow: ellipsis;
+
             }
           </style>
-          <strong>[[item.textname]]</strong><br /><span class="display-name">[[item.displayName]]</span>
+         <paper-icon-item>
+          
+          <paper-item-body two-line>
+            <div>
+              <strong>[[item.textname]]</strong> 
+              <img src="[[item.imgStringPLI]]" item-icon> 
+              <img src="[[item.imgStringSKT]]" item-icon> 
+              <img src="[[item.imgStringTIB]]" item-icon> 
+              <img src="[[item.imgStringCHN]]" item-icon> 
+            </div>
+            <div secondary><span class="display-name">[[item.displayName]]</span></div>
+          </paper-item-body>
+        </paper-icon-item>
         </template>
       </vaadin-combo-box>
 

--- a/src/views/data/data-view-header-fields.js
+++ b/src/views/data/data-view-header-fields.js
@@ -121,12 +121,12 @@ export class DataViewHeaderFields extends LitElement {
   }
 
     preprocessMenuData(menuData) {
-	// this function has a bit of spaghetti-style; maybe we can refactor it at some point. 
+	// this function has a bit of spaghetti-style; maybe we can refactor it at some point.
 	return menuData.map(menuEntry => {
 	    menuEntry.imgStringPLI = '';
 	    menuEntry.imgStringSKT = '';
 	    menuEntry.imgStringTIB = '';
-	    menuEntry.imgStringCHN = '';	    
+	    menuEntry.imgStringCHN = '';
 	    if(menuEntry.available_lang.length > 0 ) {
 		menuEntry.available_lang.forEach(langItem => {
 		    if(langItem == "pli") {
@@ -265,14 +265,13 @@ export class DataViewHeaderFields extends LitElement {
             }
           </style>
          <paper-icon-item>
-          
           <paper-item-body two-line>
             <div>
-              <strong>[[item.textname]]</strong> 
-              <img src="[[item.imgStringPLI]]" item-icon> 
-              <img src="[[item.imgStringSKT]]" item-icon> 
-              <img src="[[item.imgStringTIB]]" item-icon> 
-              <img src="[[item.imgStringCHN]]" item-icon> 
+              <strong>[[item.textname]]</strong>
+              <img src="[[item.imgStringPLI]]" item-icon>
+              <img src="[[item.imgStringSKT]]" item-icon>
+              <img src="[[item.imgStringTIB]]" item-icon>
+              <img src="[[item.imgStringCHN]]" item-icon>
             </div>
             <div secondary><span class="display-name">[[item.displayName]]</span></div>
           </paper-item-body>

--- a/src/views/data/data-view-header-fields.js
+++ b/src/views/data/data-view-header-fields.js
@@ -6,6 +6,7 @@ import '@vaadin/vaadin-select/theme/material/vaadin-select';
 import { LANGUAGE_CODES } from '../utility/constants';
 import { getFilesForMainMenu, getFoliosForFile } from '../menus/actions';
 import { DATA_VIEW_MODES } from './data-view-filters-container';
+import { preprocessMenuData } from '../utility/utils';
 
 @customElement('data-view-header-fields')
 export class DataViewHeaderFields extends LitElement {
@@ -120,37 +121,6 @@ export class DataViewHeaderFields extends LitElement {
     }
   }
 
-  preprocessMenuData(menuData) {
-    // this function has a bit of spaghetti-style; maybe we can refactor it at some point.
-    return menuData.map(menuEntry => {
-      menuEntry.imgStringPLI = '';
-      menuEntry.imgStringSKT = '';
-      menuEntry.imgStringTIB = '';
-      menuEntry.imgStringCHN = '';
-      if (menuEntry.available_lang) {
-        menuEntry.available_lang.forEach(langItem => {
-          if (langItem == 'pli') {
-            menuEntry.imgStringPLI =
-              '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
-          }
-          if (langItem == 'skt') {
-            menuEntry.imgStringSKT =
-              '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
-          }
-          if (langItem == 'tib') {
-            menuEntry.imgStringTIB =
-              '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
-          }
-          if (langItem == 'chn') {
-            menuEntry.imgStringCHN =
-              '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
-          }
-        });
-      }
-      return menuEntry;
-    });
-  }
-
   getTextAndDisplayNames(results) {
     const textNameDic = {};
     const displayNameDic = {};
@@ -172,7 +142,7 @@ export class DataViewHeaderFields extends LitElement {
       language: this.language,
     });
 
-    this.menuData = this.preprocessMenuData(result);
+    this.menuData = preprocessMenuData(result);
 
     this.fetchError = error;
   }
@@ -266,18 +236,14 @@ export class DataViewHeaderFields extends LitElement {
 
             }
           </style>
-         <paper-icon-item>
-          <paper-item-body two-line>
-            <div>
-              <strong>[[item.textname]]</strong>
-              <img src="[[item.imgStringPLI]]" item-icon>
-              <img src="[[item.imgStringSKT]]" item-icon>
-              <img src="[[item.imgStringTIB]]" item-icon>
-              <img src="[[item.imgStringCHN]]" item-icon>
-            </div>
-            <div secondary><span class="display-name">[[item.displayName]]</span></div>
-          </paper-item-body>
-        </paper-icon-item>
+          <div>
+            <strong>[[item.textname]]</strong>
+            <img src="[[item.imgStringPLI]]" item-icon>
+            <img src="[[item.imgStringSKT]]" item-icon>
+            <img src="[[item.imgStringTIB]]" item-icon>
+            <img src="[[item.imgStringCHN]]" item-icon>
+          </div>
+          <div secondary><span class="display-name">[[item.displayName]]</span></div>
         </template>
       </vaadin-combo-box>
 

--- a/src/views/data/data-view-router.js
+++ b/src/views/data/data-view-router.js
@@ -98,10 +98,12 @@ export class DataViewRouter extends LitElement {
         ></table-view-multilang>
       `;
     } else if (this.selectedView === DATA_VIEW_MODES.NEUTRAL) {
+
       return html`
         <neutral-view .lang="${this.lang}"></neutral-view>
       `;
     } else {
+	console.log("FAILED VIEWMODE",this.selectedView);
       return html`
         <h2>Select the view mode.</h2>
       `;

--- a/src/views/data/data-view-view-selector.js
+++ b/src/views/data/data-view-view-selector.js
@@ -38,8 +38,7 @@ export class DataViewViewSelector extends LitElement {
       >
         ${Object.values(DATA_VIEW_MODES).map(filter => {
           if (
-            (filter !== 'numbers' || this.language !== 'tib') &&
-            (filter !== 'numbers' || this.language !== 'skt') &&
+            (filter !== 'numbers' || (this.language !== 'tib' && this.language !== 'skt' && this.language !== 'multi')) &&
             filter !== 'neutral' &&
             (filter !== 'multilang' || this.multiLingualMode.length > 1) &&
             filter !== 'text-search'

--- a/src/views/data/data-view.js
+++ b/src/views/data/data-view.js
@@ -3,7 +3,6 @@
  *
  * @todo:
  * - pass filter values inside an object instead of separately in order to simplify code.
- * - get rid of one of this.selectedView/this.viewMode
  */
 
 import { customElement, html, LitElement, property } from 'lit-element';
@@ -53,7 +52,6 @@ export class DataView extends LitElement {
   ];
   @property({ type: String }) activeSegment;
   @property({ type: String }) folio;
-  @property({ type: String }) selectedView;
   @property({ type: String }) headerVisibility = '';
   @property({ type: Boolean }) filterBarOpen;
   @property({ type: Boolean }) showSegmentNumbers;
@@ -98,11 +96,6 @@ export class DataView extends LitElement {
         this.score = DEFAULT_SCORES.CHINESE;
         this.multiLingualMode = [LANGUAGE_CODES.CHINESE];
         break;
-      // Question: DO we need this default value?
-      default:
-        this.minLength = MIN_LENGTHS.TIBETAN;
-        this.quoteLength = DEFAULT_LENGTHS.TIBETAN;
-        this.score = DEFAULT_SCORES.TIBETAN;
     }
     this.checkSelectedView();
   }
@@ -114,17 +107,7 @@ export class DataView extends LitElement {
         this.updateFileNameParamInUrl(this.fileName, this.activeSegment);
         this.checkSearchSelectedText();
       }
-      if (
-        [
-          'score',
-          'cooccurance',
-          'sortMethod',
-          'quoteLength',
-          'multiLingualMode',
-        ].includes(propName)
-      ) {
-        this.applyFilter();
-      }
+
       if (propName === 'language') {
         getMainLayout()
           .querySelector('navigation-menu')
@@ -159,19 +142,25 @@ export class DataView extends LitElement {
     }
   }
 
-  checkSelectedView() {
-    if (this.selectedView === DATA_VIEW_MODES.NEUTRAL && this.fileName) {
-      this.selectedView = DATA_VIEW_MODES.TEXT;
-      this.viewMode = DATA_VIEW_MODES.TEXT;
-      const newUrl = this.location.pathname.replace('neutral', 'text');
-      this.location.pathname = newUrl;
-      history.replaceState({}, null, newUrl);
+  checkSelectedView() { 
+      if (this.viewMode === DATA_VIEW_MODES.NEUTRAL && this.fileName) {
+	  let newUrl;
+	  if (this.language != LANGUAGE_CODES.MULTILANG) {
+	      this.viewMode = DATA_VIEW_MODES.TEXT;
+	      newUrl = this.location.pathname.replace('neutral', 'text');
+	  }
+	  else {
+	      this.viewMode = DATA_VIEW_MODES.MULTILANG;
+	      newUrl = this.location.pathname.replace('neutral', 'multi');
+	  }
+	  this.location.pathname = newUrl;
+	  history.replaceState({}, null, newUrl);
+	      
     }
   }
   // handles the case that a new text was selected while browsing the search-results in local-search-view.
   checkSearchSelectedText() {
-    if (this.selectedView === DATA_VIEW_MODES.TEXT_SEARCH && this.fileName) {
-      this.selectedView = DATA_VIEW_MODES.TEXT;
+    if (this.viewMode === DATA_VIEW_MODES.TEXT_SEARCH && this.fileName) {
       this.viewMode = DATA_VIEW_MODES.TEXT;
     }
   }
@@ -195,7 +184,6 @@ export class DataView extends LitElement {
   };
 
   setSelectedView = viewName => {
-    this.selectedView = viewName;
     this.viewMode = viewName;
   };
 
@@ -214,7 +202,6 @@ export class DataView extends LitElement {
   setSearch = searchString => {
     this.searchString = searchString;
     this.viewMode = DATA_VIEW_MODES.TEXT_SEARCH;
-    this.selectedView = DATA_VIEW_MODES.TEXT_SEARCH;
   };
 
   setMultiLangSearch = searchString => {
@@ -251,16 +238,12 @@ export class DataView extends LitElement {
       this.setLimitOrTargetCollection =
         this.viewMode == 'graph' ? this.targetCollection : this.limitCollection;
     }
-    if (this.fileName) {
-      this.applyFilter();
-    }
+
   };
 
   setTargetCollection = targetCollection => {
     this.targetCollection = targetCollection;
-    if (this.fileName) {
-      this.applyFilter();
-    }
+
   };
 
   updateFileNameParamInUrl(fileName, activeSegment) {
@@ -298,16 +281,9 @@ export class DataView extends LitElement {
     }
     this.updateViewModeParamInUrl(newViewMode);
     this.viewMode = newViewMode;
-    this.selectedView = newViewMode;
-
-    if (this.fileName) {
-      this.applyFilter();
-    }
   };
 
-  applyFilter() {
-    this.selectedView = this.viewMode;
-  }
+
 
   toggleFilterBarOpen = () => {
     this.filterBarOpen = !this.filterBarOpen;
@@ -358,7 +334,7 @@ export class DataView extends LitElement {
           </data-view-header>
 
           <data-view-router
-            .selectedView="${this.selectedView}"
+            .selectedView="${this.viewMode}"
             .setSelectedView="${this.setSelectedView}"
             .lang="${this.language}"
             .setFileName="${this.setFileName}"

--- a/src/views/data/data-view.js
+++ b/src/views/data/data-view.js
@@ -142,19 +142,18 @@ export class DataView extends LitElement {
     }
   }
 
-  checkSelectedView() { 
-      if (this.viewMode === DATA_VIEW_MODES.NEUTRAL && this.fileName) {
-	  let newUrl;
-	  if (this.language != LANGUAGE_CODES.MULTILANG) {
-	      this.viewMode = DATA_VIEW_MODES.TEXT;
-	      newUrl = this.location.pathname.replace('neutral', 'text');
-	  }
-	  else {
-	      this.viewMode = DATA_VIEW_MODES.MULTILANG;
-	      newUrl = this.location.pathname.replace('neutral', 'multi');
-	  }
-	  this.location.pathname = newUrl;
-	  history.replaceState({}, null, newUrl);     
+  checkSelectedView() {
+    if (this.viewMode === DATA_VIEW_MODES.NEUTRAL && this.fileName) {
+      let newUrl;
+      if (this.language != LANGUAGE_CODES.MULTILANG) {
+        this.viewMode = DATA_VIEW_MODES.TEXT;
+        newUrl = this.location.pathname.replace('neutral', 'text');
+      } else {
+        this.viewMode = DATA_VIEW_MODES.MULTILANG;
+        newUrl = this.location.pathname.replace('neutral', 'multi');
+      }
+      this.location.pathname = newUrl;
+      history.replaceState({}, null, newUrl);
     }
   }
   // handles the case that a new text was selected while browsing the search-results in local-search-view.
@@ -237,12 +236,10 @@ export class DataView extends LitElement {
       this.setLimitOrTargetCollection =
         this.viewMode == 'graph' ? this.targetCollection : this.limitCollection;
     }
-
   };
 
   setTargetCollection = targetCollection => {
     this.targetCollection = targetCollection;
-
   };
 
   updateFileNameParamInUrl(fileName, activeSegment) {
@@ -281,8 +278,6 @@ export class DataView extends LitElement {
     this.updateViewModeParamInUrl(newViewMode);
     this.viewMode = newViewMode;
   };
-
-
 
   toggleFilterBarOpen = () => {
     this.filterBarOpen = !this.filterBarOpen;

--- a/src/views/data/data-view.js
+++ b/src/views/data/data-view.js
@@ -154,8 +154,7 @@ export class DataView extends LitElement {
 	      newUrl = this.location.pathname.replace('neutral', 'multi');
 	  }
 	  this.location.pathname = newUrl;
-	  history.replaceState({}, null, newUrl);
-	      
+	  history.replaceState({}, null, newUrl);     
     }
   }
   // handles the case that a new text was selected while browsing the search-results in local-search-view.

--- a/src/views/menus/navigation-menu.js
+++ b/src/views/menus/navigation-menu.js
@@ -5,7 +5,7 @@ import '@vaadin/vaadin-details/theme/material/vaadin-details.js';
 import { getDataForSidebarMenu } from '../../api/actions';
 
 import styles from './navigation-menu.styles';
-import { getMainLayout } from '../utility/utils';
+import { getMainLayout, preprocessMenuData } from '../utility/utils';
 
 @customElement('navigation-menu')
 export class NavigationMenu extends LitElement {
@@ -59,16 +59,23 @@ export class NavigationMenu extends LitElement {
   }
 
   addCatagoryFiles(files) {
+    let pictureFiles = preprocessMenuData(files);
     let totalFilesList = [];
-    if (files.length !== 0) {
-      totalFilesList = files.map(
+    if (pictureFiles.length !== 0) {
+      totalFilesList = pictureFiles.map(
         file => html`
           <li
             class="filename"
             id="${file.filename}"
             @click="${this.openThisFile}"
           >
-            <strong id="${file.filename}">${file.textname}</strong>
+            <div>
+              <strong id="${file.filename}">${file.textname}</strong>
+              <img src="${file.imgStringPLI}" item-icon />
+              <img src="${file.imgStringSKT}" item-icon />
+              <img src="${file.imgStringTIB}" item-icon />
+              <img src="${file.imgStringCHN}" item-icon />
+            </div>
             ${file.displayname}
           </li>
         `

--- a/src/views/neutralview/neutral-view-multilang.js
+++ b/src/views/neutralview/neutral-view-multilang.js
@@ -1,0 +1,23 @@
+import { customElement, html, LitElement } from 'lit-element';
+
+import sharedDataViewStyles from '../data/data-view-shared.styles';
+import styles from './neutral-view.styles';
+
+@customElement('neutral-view-multilang')
+export class NeutralViewChinese extends LitElement {
+  static get styles() {
+    return [styles, sharedDataViewStyles];
+  }
+
+  render() {
+    return html`
+      <div class="static-page-container lang_chn">
+        <div class="main-border">
+          <div class="main-content">
+            <h2>Files available in multilingual format</h2>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/views/neutralview/neutral-view.js
+++ b/src/views/neutralview/neutral-view.js
@@ -4,6 +4,7 @@ import './neutral-view-sanskrit';
 import './neutral-view-tibetan';
 import './neutral-view-chinese';
 import './neutral-view-pali';
+import './neutral-view-multilang';
 
 import { LANGUAGE_CODES } from '../utility/constants';
 
@@ -32,5 +33,10 @@ export class NeutralView extends LitElement {
         <neutral-view-pali></neutral-view-pali>
       `;
     }
+   if (this.lang == LANGUAGE_CODES.MULTILANG) {
+      return html`
+        <neutral-view-multilang></neutral-view-multilang>
+      `;
+    }     
   }
 }

--- a/src/views/neutralview/neutral-view.js
+++ b/src/views/neutralview/neutral-view.js
@@ -37,6 +37,6 @@ export class NeutralView extends LitElement {
       return html`
         <neutral-view-multilang></neutral-view-multilang>
       `;
-    }     
+    }
   }
 }

--- a/src/views/utility/constants.js
+++ b/src/views/utility/constants.js
@@ -3,6 +3,8 @@ export const LANGUAGE_CODES = {
   TIBETAN: 'tib',
   CHINESE: 'chn',
   SANSKRIT: 'skt',
+  MULTILANG: 'multi',
+
 };
 
 export const MIN_LENGTHS = {
@@ -24,6 +26,7 @@ export const LANGUAGE_NAMES = {
   TIBETAN: 'Tibetan',
   CHINESE: 'Chinese',
   SANSKRIT: 'Sanskrit',
+  MULTILANG: 'Multilingual',
 };
 
 export const DEFAULT_SCORES = {

--- a/src/views/utility/utils.js
+++ b/src/views/utility/utils.js
@@ -126,3 +126,34 @@ export function switchNavbarVisibility(isVisibleNavbar) {
   setLogoVisibility(isVisibleNavbar);
   setNavbarVisibility(isVisibleNavbar);
 }
+
+export function preprocessMenuData(menuData) {
+  // this function has a bit of spaghetti-style; maybe we can refactor it at some point.
+  return menuData.map(menuEntry => {
+    menuEntry.imgStringPLI = '';
+    menuEntry.imgStringSKT = '';
+    menuEntry.imgStringTIB = '';
+    menuEntry.imgStringCHN = '';
+    if (menuEntry.available_lang) {
+      menuEntry.available_lang.forEach(langItem => {
+        if (langItem == 'pli') {
+          menuEntry.imgStringPLI =
+            '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
+        }
+        if (langItem == 'skt') {
+          menuEntry.imgStringSKT =
+            '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
+        }
+        if (langItem == 'tib') {
+          menuEntry.imgStringTIB =
+            '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
+        }
+        if (langItem == 'chn') {
+          menuEntry.imgStringCHN =
+            '../../src/assets/icons/favicon-' + langItem + '-16x16.png';
+        }
+      });
+    }
+    return menuEntry;
+  });
+}


### PR DESCRIPTION
- adds icon to the right of the filename in the dropdown menu 
- adds a new "language" in the database menu called "Multilingual"
- the dropdown menu for the multilang only lists those files that have multilingual parallels
- in the multilang language, the multilang mode is set as default

TODO (maybe in a new PR):
- sidebar menu on the left side does not have the multilang icon yet
- neutral view for multilang needs styling (background image, description text etc) 
- new sidebar menu for multilang mode - sorted by lang first?