### PR TITLE
333 remove numbers view logos

### DIFF
--- a/src/views/numbersview/numbers-view-table.js
+++ b/src/views/numbersview/numbers-view-table.js
@@ -45,7 +45,8 @@ const TableRowContainer = (
   segmentParallels,
   collections,
   segmentnr,
-  language
+  language,
+  logo = false
 ) =>
   segmentParallels.map((parallelArr, index) => {
     const parCollection = getParCollectionNumber(parallelArr);
@@ -53,18 +54,19 @@ const TableRowContainer = (
       <formatted-segment
         .segmentnr="${[`${segmentnr}`]}"
         .lang="${language}"
+        .logo="${logo}"
       ></formatted-segment>
     `;
     if (collections[parCollection]) {
       collections[parCollection].push(parallelArr);
       if (index === segmentParallels.length - 1) {
         const rootLink = createTextViewSegmentUrl(segmentnr);
-        return TableRow(segmentlink, collections, language, rootLink);
+        return TableRow(segmentlink, collections, language, rootLink, logo);
       }
     }
   });
 
-const TableRow = (segmentNr, collections, language, rootLink) =>
+const TableRow = (segmentNr, collections, language, rootLink, logo) =>
   //prettier-ignore
   html`
     <tr class="numbers-view-table-row">
@@ -79,20 +81,21 @@ const TableRow = (segmentNr, collections, language, rootLink) =>
       ${Object.keys(collections).map(
         key => html`
           <td>
-            ${getParallelsForCollection(collections[key], language)}
+            ${getParallelsForCollection(collections[key], language, logo)}
           </td>
         `
       )}
     </tr>
   `;
 
-const getParallelsForCollection = (collection, language) =>
+const getParallelsForCollection = (collection, language, logo) =>
   collection.map(item => {
     const parLink = createTextViewSegmentUrl(item[0]);
     const segmentlink = html`
       <formatted-segment
         .segmentnr="${item}"
         .lang="${language}"
+        .logo="${logo}"
       ></formatted-segment>
     `;
     //prettier-ignore

--- a/src/views/utility/formatted-segment.js
+++ b/src/views/utility/formatted-segment.js
@@ -11,6 +11,7 @@ export class FormattedSegment extends LitElement {
   @property({ type: String }) segmentnr;
   @property({ type: String }) filename;
   @property({ type: String }) lang;
+  @property({ type: Boolean }) logo = true;
   @property({ type: String }) number;
   @property({ type: String }) displayName = '';
   @property({ type: String }) displayLink = '';
@@ -25,19 +26,27 @@ export class FormattedSegment extends LitElement {
   firstUpdated() {
     this.addObserver();
   }
+
   getIcon(par_lang) {
+    if (!this.logo) {
+      return;
+    }
     let title;
-    if (par_lang == 'tib') {
-      title = 'Tibetan';
-    }
-    if (par_lang == 'skt') {
-      title = 'Sanskrit';
-    }
-    if (par_lang == 'pli') {
-      title = 'Pali';
-    }
-    if (par_lang == 'chn') {
-      title = 'Chinese';
+    switch (par_lang) {
+      case 'tib':
+        title = 'Tibetan';
+        break;
+      case 'skt':
+        title = 'Sanskrit';
+        break;
+      case 'pli':
+        title = 'Pali';
+        break;
+      case 'chn':
+        title = 'Chinese';
+        break;
+      default:
+        title = '';
     }
 
     return html`
@@ -84,7 +93,7 @@ export class FormattedSegment extends LitElement {
       this.filename = this.filename.replace(/_[0-9]+/, '');
     }
     const { displayData, error } = await getDisplayName({
-      segmentnr: this.filename
+      segmentnr: this.filename,
     });
     this.displayName = displayData ? displayData[0] : '';
     if (this.lang === 'skt' || this.lang === 'tib') {


### PR DESCRIPTION
This removes the language-logos from the numbers view as it is not needed there (already sorted in columns of each collection and collections are by definition one language).