### PR TITLE
makes english view available and adds text to guidelines

### DIFF
--- a/src/views/data/data-view-header-fields.js
+++ b/src/views/data/data-view-header-fields.js
@@ -153,7 +153,7 @@ export class DataViewHeaderFields extends LitElement {
       case LANGUAGE_CODES.TIBETAN:
         return 'Find Tibetan texts...';
       case LANGUAGE_CODES.PALI:
-        return 'Find Pali texts...';
+        return 'Find Pāli texts...';
       case LANGUAGE_CODES.CHINESE:
         return 'Find Chinese texts...';
       case LANGUAGE_CODES.SANSKRIT:

--- a/src/views/data/data-view-view-selector.js
+++ b/src/views/data/data-view-view-selector.js
@@ -29,8 +29,6 @@ export class DataViewViewSelector extends LitElement {
   }
 
   render() {
-    // In the English filter, remove pli as a language to make it visible.
-    // This viewmode is temporarily hidden.
     return html`
       <vaadin-radio-group
         label="Choose view:"

--- a/src/views/data/data-view-view-selector.js
+++ b/src/views/data/data-view-view-selector.js
@@ -54,8 +54,7 @@ export class DataViewViewSelector extends LitElement {
             (filter !== 'english' ||
               (this.language !== 'skt' &&
                 this.language !== 'tib' &&
-                this.language !== 'chn' &&
-                this.language !== 'pli'))
+                this.language !== 'chn'))
           ) {
             return html`
               <vaadin-radio-button value="${filter}">

--- a/src/views/englishview/EnglishSegment.js
+++ b/src/views/englishview/EnglishSegment.js
@@ -1,5 +1,7 @@
 import { html } from 'lit-element';
 
+import { createTextViewSegmentUrl } from '../data/dataViewUtils';
+
 export function EnglishSegmentContainer({
   segmentNr,
   segText,
@@ -58,24 +60,10 @@ const PaliSegment = (inputData, segmentNr) => {
       `;
 };
 
-function openInNewTab(segmentNr) {
-  let segmentnr = segmentNr;
-  if (segmentNr.startsWith('ai-') || segmentNr.startsWith('en-')) {
-    segmentnr = segmentNr.replace('ai-', '').replace('en-', '') + '_0';
-  }
-  let fileName = segmentnr.split(':')[0];
-  const currentURL = window.location.href.split('/');
-  currentURL.pop();
-  return (
-    currentURL
-      .join()
-      .replace(/,/g, '/')
-      .replace('english', 'text') +
-    '/' +
-    fileName +
-    '/' +
-    segmentnr.replace(/\./g, '@')
-  );
+function convertSegment(segmentNr) {
+  return segmentNr.startsWith('ai-') || segmentNr.startsWith('en-')
+    ? (segmentNr = segmentNr.replace('ai-', '').replace('en-', '') + '_0')
+    : segmentNr;
 }
 
 export function EnglishSegment({
@@ -92,7 +80,7 @@ export function EnglishSegment({
   return html`${firstDisplayNumber
                   ? html`
                     <a class="segment-number ${segmentDisplaySide}"
-                      href="${openInNewTab(segmentNr)}"
+                      href="${createTextViewSegmentUrl(convertSegment(segmentNr))}"
                       target="_blank"
                       show-number="${showSegmentNumbers}">${displayNumber}</a>`
                   : null

--- a/src/views/englishview/EnglishSegment.js
+++ b/src/views/englishview/EnglishSegment.js
@@ -58,6 +58,26 @@ const PaliSegment = (inputData, segmentNr) => {
       `;
 };
 
+function openInNewTab(segmentNr) {
+  let segmentnr = segmentNr;
+  if (segmentNr.startsWith('ai-') || segmentNr.startsWith('en-')) {
+    segmentnr = segmentNr.replace('ai-', '').replace('en-', '') + '_0';
+  }
+  let fileName = segmentnr.split(':')[0];
+  const currentURL = window.location.href.split('/');
+  currentURL.pop();
+  return (
+    currentURL
+      .join()
+      .replace(/,/g, '/')
+      .replace('english', 'text') +
+    '/' +
+    fileName +
+    '/' +
+    segmentnr.replace(/\./g, '@')
+  );
+}
+
 export function EnglishSegment({
   segmentNr,
   segText,
@@ -69,15 +89,16 @@ export function EnglishSegment({
   onClick,
 }) {
   // prettier-ignore
-  return html`<span class="segment ${highLightSegment ? 'segment--highlighted' : ''}"
-                title=${displayNumber}
-                id=${segmentNr}
-                @click="${onClick}">
-                ${firstDisplayNumber
+  return html`${firstDisplayNumber
                   ? html`
-                    <span class="segment-number ${segmentDisplaySide}"
-                      show-number="${showSegmentNumbers}">${displayNumber}</span>`
+                    <a class="segment-number ${segmentDisplaySide}"
+                      href="${openInNewTab(segmentNr)}"
+                      target="_blank"
+                      show-number="${showSegmentNumbers}">${displayNumber}</a>`
                   : null
                 }
-                ${segText}</span>`
+                <span class="segment ${highLightSegment ? 'segment--highlighted' : ''}"
+                title=${displayNumber}
+                id=${segmentNr}
+                @click="${onClick}">${segText}</span>`
 }

--- a/src/views/englishview/EnglishSegment.js
+++ b/src/views/englishview/EnglishSegment.js
@@ -26,7 +26,7 @@ export function EnglishSegmentContainer({
       ? false
       : true;
 
-  let newSegText = PaliSegment(segText);
+  let newSegText = PaliSegment(segText, segmentNr);
   return EnglishSegment({
     segmentNr: segmentNr,
     segText: newSegText,
@@ -39,12 +39,13 @@ export function EnglishSegmentContainer({
   });
 }
 
-const PaliSegment = inputData => {
+const PaliSegment = (inputData, segmentNr) => {
   if (!inputData) {
     return;
   }
   const strippedSegment = inputData.replace(/\//g, '|').trim();
-  return strippedSegment.match(/^[0-9]/g) || strippedSegment.match(/[0-9]$/g)
+  return !segmentNr.match(/^(ai-anya|ai-tika|ai-atk)/g) &&
+    (strippedSegment.match(/^[0-9]/g) || strippedSegment.match(/[0-9]$/g))
     ? html`
         <h3>${strippedSegment}</h3>
       `

--- a/src/views/englishview/english-view-header.js
+++ b/src/views/englishview/english-view-header.js
@@ -141,7 +141,7 @@ export class EnglishViewHeader extends LitElement {
           <source-link .filename="${this.fileName}"></source-link>
         </div>
 
-        <div>Artificial Intelligence Translation</div>
+        <div>(Beta version) AI Translation</div>
 
         ${this.displaySCEnglish
           ? EnglishViewHeaderRightColumn({

--- a/src/views/englishview/english-view-header.js
+++ b/src/views/englishview/english-view-header.js
@@ -51,8 +51,8 @@ function EnglishViewHeaderLeftColumn({
       <template>
         <div>
           <p>
-            This view shows the original Pali text in the left column and the english translations.
-            The right column shows the text by our artificial intelligence neural network computer.
+            This view shows the original Pāli text in the left column and the english translations.
+            The right column shows the translation by our artificial intelligence neural network computer.
           </p><p>
             In the settings menu there is an option to show the human english translation by
             Bhikkhu Sujato (Suttas) or Bhikkhu Bhahmali (Vinaya) if these exist.

--- a/src/views/englishview/english-view-header.js
+++ b/src/views/englishview/english-view-header.js
@@ -53,6 +53,8 @@ function EnglishViewHeaderLeftColumn({
           <p>
             This view shows the original Pāli text in the left column and the english translations.
             The right column shows the translation by our artificial intelligence neural network computer.
+            Note: This view is experimental and the translations by the neural network cannot be relied
+            upon as actual correct translations.
           </p><p>
             In the settings menu there is an option to show the human english translation by
             Bhikkhu Sujato (Suttas) or Bhikkhu Bhahmali (Vinaya) if these exist.

--- a/src/views/englishview/english-view-header.js
+++ b/src/views/englishview/english-view-header.js
@@ -72,7 +72,7 @@ function EnglishViewHeaderLeftColumn({
 @customElement('english-view-header')
 export class EnglishViewHeader extends LitElement {
   @property({ type: String }) fileName;
-  @property({ type: Boolean }) showSCEnglish;
+  @property({ type: Boolean }) displaySCEnglish;
 
   @property({ type: Boolean }) isInfoDialogRightOpen = false;
   @property({ type: Boolean }) isInfoDialogLeftOpen = false;
@@ -141,7 +141,7 @@ export class EnglishViewHeader extends LitElement {
 
         <div>Artificial Intelligence Translation</div>
 
-        ${this.showSCEnglish
+        ${this.displaySCEnglish
           ? EnglishViewHeaderRightColumn({
               isInfoDialogRightOpen: this.isInfoDialogRightOpen,
               openDialogRight: this.openDialogRight,

--- a/src/views/englishview/english-view-left.js
+++ b/src/views/englishview/english-view-left.js
@@ -1,11 +1,8 @@
 import { customElement, html, LitElement, property } from 'lit-element';
-// import { removeDuplicates } from '../utility/views-common';
-// import { getFileText } from '../../api/actions';
 
 import sharedDataViewStyles from '../data/data-view-shared.styles';
 import styles from './english-view-table.styles';
 import { EnglishSegmentContainer } from './EnglishSegment';
-// import { C_HIGHLIGHTED_SEGMENT, C_SELECTED_SEGMENT } from './english-view';
 
 @customElement('english-view-left')
 export class EnglishViewLeft extends LitElement {

--- a/src/views/englishview/english-view-left.js
+++ b/src/views/englishview/english-view-left.js
@@ -33,6 +33,11 @@ export class EnglishViewLeft extends LitElement {
         if (allSegments) {
           allSegments[0].scrollIntoView();
         }
+      } else {
+        let allSegments = this.shadowRoot.querySelectorAll('.segment');
+        if (allSegments) {
+          allSegments[0].scrollIntoView();
+        }
       }
     });
   }

--- a/src/views/englishview/english-view-middle.js
+++ b/src/views/englishview/english-view-middle.js
@@ -30,6 +30,11 @@ export class EnglishViewMiddle extends LitElement {
         if (allSegments[0]) {
           allSegments[0].scrollIntoView();
         }
+      } else {
+        let allSegments = this.shadowRoot.querySelectorAll('.segment');
+        if (allSegments) {
+          allSegments[0].scrollIntoView();
+        }
       }
     });
   }

--- a/src/views/englishview/english-view-right.js
+++ b/src/views/englishview/english-view-right.js
@@ -12,6 +12,7 @@ export class EnglishViewRight extends LitElement {
   @property({ type: Boolean }) showSegmentNumbers;
   @property({ type: String }) segmentDisplaySide;
   @property({ type: Function }) handleSegmentClick;
+  @property({ type: Boolean }) displaySCEnglish;
 
   static get styles() {
     return [sharedDataViewStyles, styles];
@@ -20,7 +21,9 @@ export class EnglishViewRight extends LitElement {
   updated(_changedProperties) {
     _changedProperties.forEach((oldValue, propName) => {
       if (
-        ['rightTextData', 'activeSegment'].includes(propName) &&
+        ['rightTextData', 'activeSegment', 'displaySCEnglish'].includes(
+          propName
+        ) &&
         this.activeSegment &&
         this.activeSegment !== 'none'
       ) {

--- a/src/views/englishview/english-view-right.js
+++ b/src/views/englishview/english-view-right.js
@@ -30,6 +30,11 @@ export class EnglishViewRight extends LitElement {
         if (allSegments[0]) {
           allSegments[0].scrollIntoView();
         }
+      } else {
+        let allSegments = this.shadowRoot.querySelectorAll('.segment');
+        if (allSegments) {
+          allSegments[0].scrollIntoView();
+        }
       }
     });
   }

--- a/src/views/englishview/english-view-table.js
+++ b/src/views/englishview/english-view-table.js
@@ -9,7 +9,7 @@ import './english-view-right';
 @customElement('english-view-table')
 export default class EnglishViewTable extends LitElement {
   @property({ type: String }) fileName;
-  @property({ type: Boolean }) showSCEnglish;
+  @property({ type: Boolean }) displaySCEnglish;
   @property({ type: Array }) leftTextData;
   @property({ type: Array }) middleData;
   @property({ type: Array }) rightTextData;
@@ -50,7 +50,7 @@ export default class EnglishViewTable extends LitElement {
             ></english-view-middle>
           </div>
 
-          ${this.showSCEnglish && this.renderRightData()}
+          ${this.displaySCEnglish && this.renderRightData()}
         </vaadin-split-layout>
       </div>
     `;
@@ -68,6 +68,7 @@ export default class EnglishViewTable extends LitElement {
           .showSegmentNumbers="${this.showSegmentNumbers}"
           .segmentDisplaySide="${this.segmentDisplaySide}"
           .handleSegmentClick="${this.handleSegmentClick}"
+          .displaySCEnglish="${this.displaySCEnglish}"
         ></english-view-right>
       </div>
     `;

--- a/src/views/englishview/english-view-table.styles.js
+++ b/src/views/englishview/english-view-table.styles.js
@@ -36,6 +36,7 @@ export default css`
   .segment-number {
     color: var(--color-text-secondary);
     font-size: 10px;
+    text-decoration: none;
   }
 
   .segment-number.left {

--- a/src/views/englishview/english-view.js
+++ b/src/views/englishview/english-view.js
@@ -24,6 +24,7 @@ export class EnglishView extends LitElement {
   updated(_changedProperties) {
     _changedProperties.forEach((oldValue, propName) => {
       if (['fileName', 'transMethod'].includes(propName)) {
+        this.activeSegment = 'none';
         this.fetchNewText();
       }
       if (propName === 'folio') {

--- a/src/views/englishview/english-view.js
+++ b/src/views/englishview/english-view.js
@@ -14,6 +14,7 @@ export class EnglishView extends LitElement {
   @property({ type: String }) segmentDisplaySide;
   @property({ type: String }) headerVisibility;
   @property({ type: Boolean }) showSCEnglish;
+  @property({ type: Boolean }) displaySCEnglish;
   @property({ type: String }) transMethod;
 
   @property({ type: Array }) rightTextData;
@@ -23,8 +24,23 @@ export class EnglishView extends LitElement {
 
   updated(_changedProperties) {
     _changedProperties.forEach((oldValue, propName) => {
-      if (['fileName', 'transMethod'].includes(propName)) {
+      if (propName === 'fileName') {
         this.activeSegment = 'none';
+        if (
+          this.fileName.match(
+            '^(atk|tik|any|[bkpv]v|th[ai]-|cp|[yj]a|[cm]nd|[dp][psa]|[np]e|mil|pli-tv-p|vb|dt)'
+          )
+        ) {
+          this.displaySCEnglish = false;
+        } else {
+          this.displaySCEnglish = this.showSCEnglish;
+        }
+        this.fetchNewText();
+      }
+      if (propName === 'showSCEnglish') {
+        this.displaySCEnglish = this.showSCEnglish;
+      }
+      if (propName === 'transMethod') {
         this.fetchNewText();
       }
       if (propName === 'folio') {
@@ -62,13 +78,13 @@ export class EnglishView extends LitElement {
         : null}
       <english-view-header
         .fileName="${this.fileName}"
-        .showSCEnglish="${this.showSCEnglish}"
+        .displaySCEnglish="${this.displaySCEnglish}"
       ></english-view-header>
 
       <english-view-table
         id="english-view-table"
         .fileName="${this.fileName}"
-        .showSCEnglish="${this.showSCEnglish}"
+        .displaySCEnglish="${this.displaySCEnglish}"
         .leftTextData="${this.leftTextData}"
         .middleData="${this.middleData}"
         .rightTextData="${this.rightTextData}"

--- a/src/views/static/guidelines/guidelines-view.js
+++ b/src/views/static/guidelines/guidelines-view.js
@@ -100,6 +100,10 @@ export class GuidelinesView extends LitElement {
                 The pie graph displays the distribution of the (approximate) matches according to the collection’s sections. 
                 The histogram shows the distribution of the top files that have matches with the Inquiry Text based on the 
                 accumulated length of the approximate matches. A maximum of 50 Hit Texts are shown.</li>
+                <li><b>English View</b>: This view-mode is only available for Pāli texts. It displays the original text
+                together with the English translatiosn by our artificial intelligence neural network computer. As an extra option
+                there is the possibility to show the human english translation by Bhikkhu Sujato (Suttas) or Bhikkhu Bhahmali (Vinaya)
+                if these exist.</li>
               </ul>
             </p>
             <h3>Visual Charts</h3>

--- a/src/views/utility/formatted-segment.js
+++ b/src/views/utility/formatted-segment.js
@@ -47,7 +47,7 @@ export class FormattedSegment extends LitElement {
         title = 'Sanskrit';
         break;
       case 'pli':
-        title = 'Pali';
+        title = 'Pāli';
         break;
       case 'chn':
         title = 'Chinese';

--- a/src/views/visual/visual-view-header.js
+++ b/src/views/visual/visual-view-header.js
@@ -17,7 +17,7 @@ export class VisualViewHeader extends LitElement {
   @property({ type: String }) colorScheme = 'Gradient';
   @property({ type: Array }) languages = [
     { language: 'tib', label: 'Tibetan' },
-    { language: 'pli', label: 'Pali' },
+    { language: 'pli', label: 'Pāli' },
     { language: 'skt', label: 'Sanskrit' },
     { language: 'chn', label: 'Chinese' },
   ];


### PR DESCRIPTION
This makes the English view visible and adds some text to the guidelines.
It will require a make load-menu-data and make load-english-data for it to work.

Changes made are:
1. Replace the word Pali with a long a everywhere.
2. Make English View mode possible in the top header.
3. Changes to English View mode to add link to the segment numbers to open up in Text View mode.
4. Change to the guidelines: 
`<li><b>English View</b>: This view-mode is only available for Pāli texts. It displays the original text
                together with the English translatiosn by our artificial intelligence neural network computer. As an extra option
                there is the possibility to show the human english translation by Bhikkhu Sujato (Suttas) or Bhikkhu Bhahmali (Vinaya)
                if these exist.</li>`