### PR TITLE
warning symbol for long filenames

### DIFF
--- a/src/views/data/data-view-filters-container.js
+++ b/src/views/data/data-view-filters-container.js
@@ -56,6 +56,7 @@ export class DataViewFiltersContainer extends LitElement {
   @property({ type: String }) filterFilesDataError = false;
   @property({ type: Boolean }) filterCategoriesDataLoading = true;
   @property({ type: String }) filterCategoriesDataError = false;
+  @property({ type: Boolean }) isDialogOpen = false;
 
   static get styles() {
     return [
@@ -169,6 +170,13 @@ export class DataViewFiltersContainer extends LitElement {
     );
   }
 
+  shouldNotShowWarningMessage() {
+    // This message is only necessary as long as long
+    // filenames in multiselect comboboxes are not
+    // resolved.
+    return this.language === 'pli' || this.language === 'chn';
+  }
+
   renderMultiSelectBox(label, id, changefunction, itempath, path) {
     return html`
       <multiselect-combo-box
@@ -246,6 +254,10 @@ export class DataViewFiltersContainer extends LitElement {
     }
   }
 
+  openDialog = () => (this.isDialogOpen = true);
+
+  setIsDialogOpen = e => (this.isDialogOpen = e.detail.value);
+
   render() {
     const shouldShowMultiLingFilters =
       this.viewMode !== DATA_VIEW_MODES.MULTILING;
@@ -275,6 +287,24 @@ export class DataViewFiltersContainer extends LitElement {
         .updateCooccurance="${this.updateCooccurance}">
       </data-view-filter-sliders>
       
+      <vaadin-button
+        class="info-button"
+        style="display: ${this.shouldNotShowWarningMessage() ? 'none' : 'inline-flex'}"
+        title="Warning Sanskrit &amp; Tibetan files"
+        @click="${this.openDialog}">
+        <iron-icon class="info-icon" icon="vaadin:warning"></iron-icon>
+      </vaadin-button>
+
+      <vaadin-dialog
+        id="info-number-view"
+        aria-label="simple"
+        .opened="${this.isDialogOpen}"
+        @opened-changed="${this.setIsDialogOpen}">
+        <template>
+          <p>Some warning text</p>
+        </template>
+      </vaadin-dialog>
+
       <multiselect-combo-box
         Label="Filter by target collection:"
         item-label-path="collectionname"

--- a/src/views/data/data-view-filters-container.js
+++ b/src/views/data/data-view-filters-container.js
@@ -301,7 +301,9 @@ export class DataViewFiltersContainer extends LitElement {
         .opened="${this.isDialogOpen}"
         @opened-changed="${this.setIsDialogOpen}">
         <template>
-          <p>Currently the dropdown menus are not working correctly when files with very long names are selected. The close-button has the tendency to disappear to the far right and becomes invisible in these cases. It is possible to unselect such files by reopening the dropdown menu and unselecting the respective file by clicking on them for a second time.</p>
+          <p>Currently the dropdown menus are not working correctly when files with very long names are selected. 
+             The close-button has the tendency to disappear to the far right and becomes invisible in these cases. 
+             It is possible to deselect such files by reopening the dropdown menu and deselecting the respective file by clicking on them for a second time.</p>
         </template>
       </vaadin-dialog>
 

--- a/src/views/data/data-view-filters-container.js
+++ b/src/views/data/data-view-filters-container.js
@@ -290,7 +290,7 @@ export class DataViewFiltersContainer extends LitElement {
       <vaadin-button
         class="info-button"
         style="display: ${this.shouldNotShowWarningMessage() ? 'none' : 'inline-flex'}"
-        title="Warning Sanskrit &amp; Tibetan files"
+        title="Dropdown menu warning"
         @click="${this.openDialog}">
         <iron-icon class="info-icon" icon="vaadin:warning"></iron-icon>
       </vaadin-button>
@@ -301,7 +301,7 @@ export class DataViewFiltersContainer extends LitElement {
         .opened="${this.isDialogOpen}"
         @opened-changed="${this.setIsDialogOpen}">
         <template>
-          <p>Some warning text</p>
+          <p>Currently the dropdown menus are not working correctly when files with very long names are selected. The close-button has the tendency to disappear to the far right and becomes invisible in these cases. It is possible to unselect such files by reopening the dropdown menu and unselecting the respective file by clicking on them for a second time.</p>
         </template>
       </vaadin-dialog>
 

--- a/src/views/data/data-view-filters-container.styles.js
+++ b/src/views/data/data-view-filters-container.styles.js
@@ -36,7 +36,16 @@ export default css`
   }
 
   .filter-group {
-    margin-top: 16px;
     margin-bottom: 16px;
+  }
+
+  .info-button {
+    background-color: transparent;
+    cursor: help;
+  }
+
+  .info-icon {
+    color: var(--bn-dark-red);
+    padding: 0;
   }
 `;


### PR DESCRIPTION
Replace "Some warning text" with whatever text you want there in data-view-filters-container.
Only shows for Sanskrit and Tibetan files.
Maybe you also want to change the title element. Make sure to use `&amp;` and not `&`.