### PR TITLE
411 move transliteration to settings menu

### DIFF
--- a/src/views/data/data-view-header.js
+++ b/src/views/data/data-view-header.js
@@ -21,7 +21,6 @@ class DataViewHeader extends LitElement {
   @property({ type: Function }) setFolio;
   @property({ type: Function }) handleViewModeChanged;
   @property({ type: Function }) toggleFilterBarOpen;
-  @property({ type: Function }) toggleTransMode;
   @property({ type: String }) searchString;
 
   static get styles() {
@@ -73,34 +72,11 @@ class DataViewHeader extends LitElement {
         vaadin-text-field [part='value'] {
           padding-left: 16px;
         }
-
-        vaadin-radio-button,
-        vaadin-radio-group {
-          --material-primary-color: var(--bn-dark-red);
-          --material-primary-text-color: var(--bn-dark-red);
-        }
-
-        .button-font {
-          color: var(--color-text-secondary);
-          font-size: 14px;
-          font-family: var(--system-font-stack);
-          font-weight: 400;
-        }
-
-        .toggle-transliteration-scheme {
-          padding-left: 12px;
-          position: absolute;
-          right: 120px;
-        }
       `,
     ];
   }
 
   render() {
-    const shouldShowTransliterationSlider =
-      ((this.language === 'tib' || this.language === 'multi') &&
-        this.viewMode != 'graph') ||
-      this.viewMode === 'english';
     //prettier-ignore
     return html`
       <div class="data-view-header">
@@ -129,21 +105,6 @@ class DataViewHeader extends LitElement {
               .updateMultiLingSearch="${this.updateMultiLingSearch}"
               .updateSortMethod="${this.updateSortMethod}">
             </data-view-header-fields>
-
-            ${shouldShowTransliterationSlider
-              ? html`
-                <vaadin-radio-group
-                  class="toggle-transliteration-scheme"
-                  label="Display text as:"
-                  @value-changed="${this.toggleTransMode}">
-                  <vaadin-radio-button value="wylie" checked>
-                    <span class="button-font">${(this.language === 'tib' || this.language === 'multi') ? 'Wylie' : 'Roman'}</span>
-                  </vaadin-radio-button>
-                  <vaadin-radio-button value="uni">
-                    <span class="button-font">${(this.language === 'tib' || this.language === 'multi') ? 'Unicode' : 'Devanagari'}</span>
-                  </vaadin-radio-button>
-                </vaadin-radio-group>`
-              : null}
 
             <iron-icon
               icon="vaadin:desktop"

--- a/src/views/data/data-view-settings-container.js
+++ b/src/views/data/data-view-settings-container.js
@@ -14,6 +14,7 @@ export class DataViewSettingsContainer extends LitElement {
   @property({ type: Function }) toggleShowSegmentNumbers;
   @property({ type: Function }) toggleSegmentDisplaySide;
   @property({ type: Function }) toggleShowSCTranslation;
+  @property({ type: Function }) toggleTransMode;
 
   static get styles() {
     return [styles];
@@ -28,8 +29,28 @@ export class DataViewSettingsContainer extends LitElement {
 
   render() {
     const shouldShowChecked = this.lang === 'pli' || this.lang === 'chn';
+    const shouldShowTransliterationSlider =
+      ((this.lang === 'tib' || this.lang === 'multi') &&
+        this.viewMode != 'graph') ||
+      this.viewMode === 'english';
     //prettier-ignore
     return html`
+        ${shouldShowTransliterationSlider
+          ? html`
+            <vaadin-radio-group
+              class="toggle-transliteration-scheme"
+              label="Display text as:"
+              @value-changed="${this.toggleTransMode}">
+              <vaadin-radio-button value="wylie" checked>
+                <span class="button-font">${(this.lang === 'tib' || this.lang === 'multi') ? 'Wylie' : 'Roman'}</span>
+              </vaadin-radio-button>
+              <vaadin-radio-button value="uni">
+                <span class="button-font">${(this.lang === 'tib' || this.lang === 'multi') ? 'Unicode' : 'Devanagari'}</span>
+              </vaadin-radio-button>
+            </vaadin-radio-group>`
+          : null}
+
+
         ${shouldShowChecked
         ? html`
             <paper-toggle-button @checked-changed="${this.toggleShowSegmentNumbers}" checked>
@@ -40,20 +61,20 @@ export class DataViewSettingsContainer extends LitElement {
               <span class="button-font">Show Segment Numbers</span>
             </paper-toggle-button>`}
 
-    <vaadin-radio-group
-      class="segment-numbers-sides"
-      @value-changed="${this.toggleSegmentDisplaySide}">
-      <vaadin-radio-button value="left" checked>
-        <span class="button-font">Left</span>
-      </vaadin-radio-button>
-      <vaadin-radio-button value="right">
-        <span class="button-font">Right</span>
-      </vaadin-radio-button>
-    </vaadin-radio-group>
+            <vaadin-radio-group
+              class="segment-numbers-sides"
+              @value-changed="${this.toggleSegmentDisplaySide}">
+              <vaadin-radio-button value="left" checked>
+                <span class="button-font">Left</span>
+              </vaadin-radio-button>
+              <vaadin-radio-button value="right">
+                <span class="button-font">Right</span>
+              </vaadin-radio-button>
+            </vaadin-radio-group>
 
-    <paper-toggle-button @checked-changed="${this.toggleShowSCTranslation}" style="${this.disableSC()}">
-      <span class="button-font">Show SuttaCentral Translation</span>
-    </paper-toggle-button>
-  `;
+            <paper-toggle-button @checked-changed="${this.toggleShowSCTranslation}" style="${this.disableSC()}">
+              <span class="button-font">Show SuttaCentral Translation</span>
+            </paper-toggle-button>
+          `;
   }
 }

--- a/src/views/data/data-view-settings-container.styles.js
+++ b/src/views/data/data-view-settings-container.styles.js
@@ -30,4 +30,8 @@ export default css`
   .segment-numbers-sides {
     margin-left: 44px;
   }
+
+  .toggle-transliteration-scheme {
+    padding-bottom: 12px;
+  }
 `;

--- a/src/views/data/data-view.js
+++ b/src/views/data/data-view.js
@@ -359,8 +359,7 @@ export class DataView extends LitElement {
             .updateSearch="${this.setSearch}"
             .multiLingualMode="${this.multiLingualMode}"
             .updateMultiLingSearch="${this.setMultiLingSearch}"
-            .updateSortMethod="${this.setSortMethod}"
-            .toggleTransMode="${this.toggleTransMode}">
+            .updateSortMethod="${this.setSortMethod}">
           </data-view-header>
 
           <data-view-router
@@ -434,7 +433,8 @@ export class DataView extends LitElement {
             .viewMode="${this.viewMode}"
             .toggleShowSegmentNumbers="${this.toggleShowSegmentNumbers}"
             .toggleSegmentDisplaySide="${this.toggleSegmentDisplaySide}"
-            .toggleShowSCTranslation="${this.toggleShowSCTranslation}">
+            .toggleShowSCTranslation="${this.toggleShowSCTranslation}"
+            .toggleTransMode="${this.toggleTransMode}">
           </data-view-settings-container>
         </side-sheet>
       </div>


### PR DESCRIPTION
This moves the transliteration to the settings menu. But maybe Orna would like it at the top.
An alternatie to this PR is https://github.com/BuddhaNexus/buddhanexus-frontend/pull/418, which moves it only for pali/english but keeps tibetan/multiling as is in the header.

Pali english view:
![Screenshot from 2021-08-15 14-59-00](https://user-images.githubusercontent.com/49606945/129479433-fb365408-193f-4336-a704-edf769e544a0.png)

Tibetan:
![Screenshot from 2021-08-15 14-59-42](https://user-images.githubusercontent.com/49606945/129479438-a175c851-5a8d-4c4b-ace2-f2d1d949a04e.png)
